### PR TITLE
Allow role usage with Python 3

### DIFF
--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -18,7 +18,7 @@ global_defs {
 {% endif %}
 }
 
-{% for key, value in keepalived_vrrp_scripts.iteritems() %}
+{% for key, value in keepalived_vrrp_scripts.items() %}
 vrrp_script {{ key }} {
   script "{{ value.script }}"
 {% if value.weight is defined %}
@@ -42,7 +42,7 @@ vrrp_script {{ key }} {
 }
 {% endfor %}
 
-{% for key, value in keepalived_vrrp_instances.iteritems() %}
+{% for key, value in keepalived_vrrp_instances.items() %}
 vrrp_instance {{ key }} {
   interface {{ value.interface }}
   state {{ value.state }}


### PR DESCRIPTION
Hi,

I'm running Ansible with Python 3 and noticed that this role doesn't work with this version as it uses iteritems() which doesn't exist anymore.

A simple fix is to switch to items() instead which is available both in versions 2 & 3. items() is said to be slower though, although I believe it is not a big deal by itself since the size of the dict is very probably limited.

Also, I'm far from being fluent in Python. So if there is another fix or solution that seems more elegant, let me know :-)